### PR TITLE
Allow for arbitrary tags in package searches

### DIFF
--- a/src/rnggui.py
+++ b/src/rnggui.py
@@ -26,6 +26,7 @@ from ui import mainwindow
 from ui import submitdialog
 import rnghelpers as rng
 import debianbts as bts
+from pysimplesoap.client import SoapFault
 from rngsettingsdialog import RngSettingsDialog
 import bug
 
@@ -181,7 +182,12 @@ class RngGui(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
                     query[i+1] = realname
         # Single bug or list of bugs?
         if query[0]:
-            buglist = bts.get_bugs(query)
+            try:
+                buglist = bts.get_bugs(query)
+            except SoapFault as soap_error:
+                buglist = []
+                # Logging is already done elsewhere, so we don't need to do
+                # anything with soap_error, besides maybe displaying the error?
         else:
             buglist = [query[1]]
         # ok, we know the package, so enable some buttons which don't depend

--- a/src/rnghelpers.py
+++ b/src/rnghelpers.py
@@ -598,21 +598,19 @@ def translate_query(query):
     ans = []
     for q in queries:
         split = q.split(':', 1)
-        logger.debug("Nested split: %s" % split)
-        if (q.startswith('src:')):
+        if (len(split)>1):
+            logger.debug("Nested split: %s" % split)
+            if (split[0] == 'from'):
+                split[0] = 'submitter'
             ans.extend(split)
-        elif (q.startswith('from:')):
-            ans.extend(['submitter', split[1]])
-        elif (q.startswith('severity:')):
-            ans.extend(split)
-        elif (q.startswith('tag:')):
-            ans.extend(split)
-        elif (q.find("@") != -1):
-            ans.extend(['maint', q])
-        elif (re.match("^[0-9]*$", q)):
-            ans.extend([None, q])
         else:
-            ans.extend(['package', q])
+            if (q.find("@") != -1):
+                ans.extend(['maint', q])
+            elif (re.match("^[0-9]*$", q)):
+                ans.extend([None, q])
+            else:
+                ans.extend(['package', q])
+
     logger.debug("Translated query to %s" % ans)
     return ans
 


### PR DESCRIPTION
It would be nice to be able to search by, for instance `archive` or any of the [other options available](https://wiki.debian.org/DebbugsSoapInterface). Instead of trying to understand them, we can just pass them all into the Soap interface and catch errors as they happen.